### PR TITLE
Who supports saf page - no change

### DIFF
--- a/docs/getting-started/who-supports-saf.md
+++ b/docs/getting-started/who-supports-saf.md
@@ -1,5 +1,6 @@
 # Who supports SAF?
 
+
 ```{admonition} Last update: August 2022
 
 Note:\


### PR DESCRIPTION
No change, trying to fix who supports saf page - no change was visible in the built documentation on the page, even though the second part of the PR - the note in the changelog was visible in the documentation.

closes #207  