### PR TITLE
Bug/212 y by vector introduction improve description

### DIFF
--- a/docs/annexes/changelog.md
+++ b/docs/annexes/changelog.md
@@ -2,6 +2,9 @@
 
 For release notes go to [Release Notes](release-notes.md). All the other (smaller) changes are documented here. This includes especially changes in wording and visuals. Improvements in the specification documented in changelog are not changing the functionality or compatibility of SAF. These changes only improve the understandability of SAF documentation.
 
+## 22.8. LCS description improved
+* Description of LCS by vector and by point in [Introduction](../getting-started/introduction.md) extended
+
 ## 18.8. SAF implementation update
 * New software MINEA now supports import of SAF
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -75,6 +75,8 @@ When is LCS enum set on **"by point"** explanation is the following:
 
 * X-axis orientation is given by system line of the member
 * X-axis direction is defined by the start point and end point of the member
+
+for **"z by point"**
 * Z-axis orientation is given by the intersection of a plane perpendicular to x and a plane defined by x-axis and point
 * Z-axis direction follow the point
 * Y-axis orientation and direction is defined by the right-hand rule
@@ -89,8 +91,14 @@ When is LCS enum set on **"by vector"** explanation is the following:
 
 * X-axis orientation is given by system line of the member
 * X-axis direction is defined by the start point and end point of the member
+
+for **"z by vector"**
 * Z-axis orientation and direction is given by vector coordinates
 * Y-axis orientation and direction is defined by right-hand rule
+
+for **"y by vector"**
+* Y-axis orientation and direction is given by vector coordinates
+* Z-axis orientation and direction is defined by right-hand rule
 
 ```{image} ../.gitbook/assets/3_introduction_lcs_by_vector_v2.png
 :width: 800px

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -76,7 +76,7 @@ When is LCS enum set on **"by point"** explanation is the following:
 * X-axis orientation is given by system line of the member
 * X-axis direction is defined by the start point and end point of the member
 
-for **"z by point"**
+For **"z by point"**
 * Z-axis orientation is given by the intersection of a plane perpendicular to x and a plane defined by x-axis and point
 * Z-axis direction follow the point
 * Y-axis orientation and direction is defined by the right-hand rule
@@ -92,11 +92,11 @@ When is LCS enum set on **"by vector"** explanation is the following:
 * X-axis orientation is given by system line of the member
 * X-axis direction is defined by the start point and end point of the member
 
-for **"z by vector"**
+For **"z by vector"**
 * Z-axis orientation and direction is given by vector coordinates
 * Y-axis orientation and direction is defined by right-hand rule
 
-for **"y by vector"**
+For **"y by vector"**
 * Y-axis orientation and direction is given by vector coordinates
 * Z-axis orientation and direction is defined by right-hand rule
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -63,7 +63,7 @@ It may help you to determine the direction of the individual structural elements
 
 ### **LCS - Local coordinate systems**
 
-Each structural entity, meaning each member, has got its own local co-ordinate system. This co-ordinate system is a three-dimensional right-handed Cartesian co-ordinate system.
+Each structural entity, meaning each member, has got its own local coordinate system. This coordinate system is a three-dimensional right-handed Cartesian coordinate system.
 
 Each member has several possibilities of enums, defining the Local Coordinate System \(LCS\). For further understanding of enums defining the LCS of the [StrucutralCurveMember](../structural-analysis-elements/structuralcurvemember.md) and [StructuralSurfaceMember](../structural-analysis-elements/structuralsurfacemember.md) see the following:
 


### PR DESCRIPTION
In the introduction page, the description of LCS by point and vector was extended. Now it should be more clear that the specific examples are related only to z by vector/point and y by vector/point is equivalent.

closes #212 