### PR TITLE
Enhancement/242 sdk names too long

### DIFF
--- a/docs/SDK/Introduction.md
+++ b/docs/SDK/Introduction.md
@@ -8,7 +8,7 @@ Check all the dependencies at [nuget.org](https://www.nuget.org/profiles/Structu
 
 There are 4 packages available:
 
-* **[StructuralAnalysisFormat](./StructuralAnalysisFormat.md)** package contains import/export functionality from and to the Structural Analysis Format in Excel.
+* The main package - **[StructuralAnalysisFormat](./StructuralAnalysisFormat.md)** contains import/export functionality from and to the Structural Analysis Format in Excel.
 
 * **[StructuralAnalysisBootstrappers.SimpleInjector4](./StructuralAnalysisFormat.Bootstrappers.SimpleInjector4.md)** package contains functionality to bootstrap SAF using SimpleInjector 4.
 

--- a/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4.md
+++ b/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4.md
@@ -1,4 +1,4 @@
-# Bootstrappers Simple Injector 4
+# Bootstrapping: SimpleInjector 4
 
 **StructuralAnalysisFormat.Bootstrappers.SimpleInjector4**
 

--- a/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4.md
+++ b/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4.md
@@ -1,4 +1,7 @@
-# StructuralAnalysisFormat.Bootstrappers.SimpleInjector4
+# Bootstrappers Simple Injector 4
+
+**StructuralAnalysisFormat.Bootstrappers.SimpleInjector4**
+
 This package will bootstrap the internal components for you, using [SimpleInjector v4](https://docs.simpleinjector.org/en/4.0/)
 
 [Download the package at nuget.org](https://www.nuget.org/packages/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4)

--- a/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5.md
+++ b/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5.md
@@ -1,4 +1,7 @@
-# StructuralAnalysisFormat.Bootstrappers.SimpleInjector5
+# Bootstrappers Simple Injector 5
+
+**StructuralAnalysisFormat.Bootstrappers.SimpleInjector5**
+
 This package will bootstrap the internal components for you, using [SimpleInjector v5](https://docs.simpleinjector.org/en/5.0/)
 
 [Download the package at nuget.org](https://www.nuget.org/packages/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5)

--- a/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5.md
+++ b/docs/SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5.md
@@ -1,4 +1,4 @@
-# Bootstrappers Simple Injector 5
+# Bootstrapping: SimpleInjector 5
 
 **StructuralAnalysisFormat.Bootstrappers.SimpleInjector5**
 

--- a/docs/SDK/StructuralAnalysisFormat.Tests.Infrastructure.md
+++ b/docs/SDK/StructuralAnalysisFormat.Tests.Infrastructure.md
@@ -1,4 +1,4 @@
-# Tests Infrastructure
+# Testing
 
 **StructuralAnalysisFormat.Tests.Infrastructure**
 

--- a/docs/SDK/StructuralAnalysisFormat.Tests.Infrastructure.md
+++ b/docs/SDK/StructuralAnalysisFormat.Tests.Infrastructure.md
@@ -1,4 +1,7 @@
-# StructuralAnalysisFormat.Tests.Infrastructure
+# Tests Infrastructure
+
+**StructuralAnalysisFormat.Tests.Infrastructure**
+
 This package adds some functionality that may come in handy for testing purposes.
 
 [Download the package at nuget.org](https://www.nuget.org/packages/StructuralAnalysisFormat.Tests.Infrastructure)

--- a/docs/SDK/StructuralAnalysisFormat.md
+++ b/docs/SDK/StructuralAnalysisFormat.md
@@ -1,4 +1,7 @@
-# StructuralAnalysisFormat
+# Structural Analysis Format
+
+**StructuralAnalysisFormat*
+
 This package implements the Structural Analysis Format in C#. The aim of this SDK is to allow anyone to rapidly get started implementing the SAF specification in their own software.
 
 [Download the package at nuget.org](https://www.nuget.org/packages/StructuralAnalysisFormat)

--- a/docs/SDK/StructuralAnalysisFormat.md
+++ b/docs/SDK/StructuralAnalysisFormat.md
@@ -1,4 +1,4 @@
-# Structural Analysis Format
+# Main package
 
 **StructuralAnalysisFormat**
 

--- a/docs/SDK/StructuralAnalysisFormat.md
+++ b/docs/SDK/StructuralAnalysisFormat.md
@@ -1,6 +1,6 @@
 # Structural Analysis Format
 
-**StructuralAnalysisFormat*
+**StructuralAnalysisFormat**
 
 This package implements the Structural Analysis Format in C#. The aim of this SDK is to allow anyone to rapidly get started implementing the SAF specification in their own software.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,6 +106,6 @@ Table of contents:
   
   SDK/Introduction.md
   SDK/StructuralAnalysisFormat.md
-  SDK/StructuralAnalysisFormat.Tests.Infrastructure
   SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector4
   SDK/StructuralAnalysisFormat.Bootstrappers.SimpleInjector5
+  SDK/StructuralAnalysisFormat.Tests.Infrastructure


### PR DESCRIPTION
changing the names of the pages for the 4 SDK packages. They were named according to the name of the package, but the name is too long to fit in the left side menu panel. 

They were changed to fit.

closes #242 