### PR TITLE
Enhancement/248 prepare master for release

### DIFF
--- a/docs/getting-started/release-notes.md
+++ b/docs/getting-started/release-notes.md
@@ -11,6 +11,9 @@ The last stable version is v2.2.0. To see it select versions: 'stable' in the le
 ### Current changes
 Current changes from stable version are noted here.
 
+
+### 28.11.2022 - Version 2.2.0
+
 **Modified objects:**
 * [StructuralCurveAction](../loads/structuralcurveaction.md) and [StructuralCurveMoment](../loads/structuralcurvemoment.md)
    * Enum "Force action" extended with value "On internal edge". "Internal edge" requirement changed:

--- a/docs/getting-started/release-notes.md
+++ b/docs/getting-started/release-notes.md
@@ -4,7 +4,7 @@
 
 **This is the latest version in progress.**
 
-The last stable version is v2.1.0. To see it select versions: 'stable' in the left bottom corner.
+The last stable version is v2.2.0. To see it select versions: 'stable' in the left bottom corner.
 
 ```
 

--- a/docs/getting-started/saf-versions.md
+++ b/docs/getting-started/saf-versions.md
@@ -23,6 +23,8 @@ Version 'latest - version in progress' is being viewed
 
 ## Previous SAF versions
 
+[2.2.0](https://www.saf.guide/en/stable/)
+
 [2.1.0](https://www.saf.guide/en/stable/)
 
 [2.0.0](https://gitbook.saf.guide/v/2.0.0/)

--- a/docs/loads/structuralloadcombination.md
+++ b/docs/loads/structuralloadcombination.md
@@ -1,9 +1,5 @@
 # StructuralLoadCombination
 
-```{warning}
-Object under construction.
-```
-
 **Load Combination**
 
 Object serves for definition a load combination. The combination is created from the existing load cases in the model, in [StructuralLoadCase](structuralloadcase.md) sheet.

--- a/docs/loads/structuralpointsupportdeformation.md
+++ b/docs/loads/structuralpointsupportdeformation.md
@@ -1,9 +1,5 @@
 # StructuralPointSupportDeformation
 
-```{warning}
-New object under construction.
-```
-
 **Imposed deformation of a point support**
 
 Displacement or rotation can be imposed on a point support. Displacement can be set in the direction of one of the axes of a support, positive displacement acts in the positive direction of the corresponding axis. Rotation can be imposed around one of the axes of a support, positive rotation acts right-handed about the corresponding positive axis. A rigid support is required in the direction of the deformation. 

--- a/docs/results/resultinternalforce2dedge.md
+++ b/docs/results/resultinternalforce2dedge.md
@@ -1,9 +1,5 @@
 # ResultInternalForce2DEdge
 
-```{warning}
-New object under construction.
-```
-
 **Internal force on 2D edge**
 
 Internal forces on edge of 2D member. The coordinate system of the results is the coordinate system of the member the results belong to.


### PR DESCRIPTION
changed for master branch (latest docs) to prepare for release of docs 2.2.0. 



In the latest do these changes:

    SAF versions - add previous SAF version
    Release notes - change the Version note, change current changes to date-Version 2.2.0, add current changes that will be empty
    StructuralLoadCombination - delete warning
    StructuralPointSuppertDeformation - delete warning
    ResultInternalForce2DEdge - delete warning

