### PR TITLE
Enhancement/248 prepare stable for release

### DIFF
--- a/docs/getting-started/release-notes.md
+++ b/docs/getting-started/release-notes.md
@@ -2,14 +2,13 @@
 
 ```{admonition} Version
 
-**This is the latest version in progress.**
+**Version**
 
-The last stable version is v2.1.0. To see it select versions: 'stable' in the left bottom corner.
+Currently displayed version 2.2.0
 
 ```
 
-### Current changes
-Current changes from stable version are noted here.
+### 28.11.2022 - Version 2.2.0
 
 **Modified objects:**
 * [StructuralCurveAction](../loads/structuralcurveaction.md) and [StructuralCurveMoment](../loads/structuralcurvemoment.md)

--- a/docs/getting-started/saf-versions.md
+++ b/docs/getting-started/saf-versions.md
@@ -18,7 +18,7 @@ It is possible to use the menu in the left bottom corner as described above, or 
 * [Stable documentation](https://www.saf.guide/en/stable/) - **currently released version** published at saf.guide
 
 ```{admonition} Currently displayed documentation
-Version 'latest - version in progress' is being viewed 
+Version 2.2.0 is being viewed
 ```
 
 ## Previous SAF versions

--- a/docs/loads/structuralloadcombination.md
+++ b/docs/loads/structuralloadcombination.md
@@ -1,9 +1,5 @@
 # StructuralLoadCombination
 
-```{warning}
-Object under construction.
-```
-
 **Load Combination**
 
 Object serves for definition a load combination. The combination is created from the existing load cases in the model, in [StructuralLoadCase](structuralloadcase.md) sheet.

--- a/docs/loads/structuralpointsupportdeformation.md
+++ b/docs/loads/structuralpointsupportdeformation.md
@@ -1,9 +1,5 @@
 # StructuralPointSupportDeformation
 
-```{warning}
-New object under construction.
-```
-
 **Imposed deformation of a point support**
 
 Displacement or rotation can be imposed on a point support. Displacement can be set in the direction of one of the axes of a support, positive displacement acts in the positive direction of the corresponding axis. Rotation can be imposed around one of the axes of a support, positive rotation acts right-handed about the corresponding positive axis. A rigid support is required in the direction of the deformation. 

--- a/docs/results/resultinternalforce2dedge.md
+++ b/docs/results/resultinternalforce2dedge.md
@@ -1,9 +1,5 @@
 # ResultInternalForce2DEdge
 
-```{warning}
-New object under construction.
-```
-
 **Internal force on 2D edge**
 
 Internal forces on edge of 2D member. The coordinate system of the results is the coordinate system of the member the results belong to.


### PR DESCRIPTION
New branch was created from master (latest). This PR changes the small things in the documentation so it is clear that this is no longer the latest branch, but it is a version 2.2.0 which will longer be changed.



In the release/2.2.0 do these changes:

    SAF versions - fix the link to stable documentation, fix the currently displayed documentations, add previous SAF version
    Release notes - change the Version note, change current changes to date-Version 2.2.0
    StructuralLoadCombination - delete warning
    StructuralPointSuppertDeformation - delete warning
    ResultInternalForce2DEdge - delete warning

closes #248 