### PR TITLE
Fix link to 2.1.0 in latest

### DIFF
--- a/docs/getting-started/saf-versions.md
+++ b/docs/getting-started/saf-versions.md
@@ -25,7 +25,7 @@ Version ‘latest - version in progress’ is being viewed
 
 [2.2.0](https://www.saf.guide/en/2.2.0)
 
-[2.1.0](https://www.saf.guide/en/2.1.0_a)
+[2.1.0](https://www.saf.guide/en/2.1.0)
 
 [2.0.0](https://gitbook.saf.guide/v/2.0.0)
 


### PR DESCRIPTION
link ended /2.1.0_a because how the documentation was created on RTD. Now fixed. -> the link needed to be fixed as well to /2.1.0

this PR is to Latest docs, there is also similar PR to stable (2.2.0 at this time) which both close #251 