### PR TITLE
Fix link to 2.1.0 in stable (2.2.0)

### DIFF
--- a/docs/getting-started/saf-versions.md
+++ b/docs/getting-started/saf-versions.md
@@ -23,9 +23,9 @@ Version 2.2.0 is being viewed
 
 ## Previous SAF versions
 
-[2.1.0](https://www.saf.guide/en/2.1.0_a/)
+[2.1.0](https://www.saf.guide/en/2.1.0)
 
-[2.0.0](https://gitbook.saf.guide/v/2.0.0/)
+[2.0.0](https://gitbook.saf.guide/v/2.0.0)
 
 [1.1.1](https://old.saf.guide/v1.1.1)
 


### PR DESCRIPTION
link ended /2.1.0_a because how the documentation was created on RTD. Now fixed. -> the link needed to be fixed as well to /2.1.0

this PR is to Stable docs, there is also similar PR to latest which both close #251 